### PR TITLE
fix windows release artifact name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           hash_file_command: 'shasum -a 256'
         - os: windows-latest
           binary_artifact_name: loftsman.exe
-          binary_publish_name: loftsman-windows-amd6.exe
+          binary_publish_name: loftsman-windows-amd64.exe
           hash_file_command: 'get-filehash -Algorithm SHA256'
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Just let us know a bit more below so we can have the info we need to review.

If you're just getting started contributing to Loftsman, make sure you review our contributing guidelines: https://github.com/Cray-HPE/loftsman/blob/main/CONTRIBUTING.md

-->

#### What type of PR is this?

fix

#### What this PR does / why we need it:

fixing GitHub release action, the windows artifact name was incomplete `amd6` instead of `amd64`

#### Which issue(s) this PR fixes or finishes:

No issue filed for it