### PR TITLE
add support for global and per-chart timeout override for Helm instal…

### DIFF
--- a/schemas/manifests/v1beta1/examples/comprehensive.yaml
+++ b/schemas/manifests/v1beta1/examples/comprehensive.yaml
@@ -2,6 +2,7 @@ apiVersion: manifests/v1beta1
 metadata:
   name: simple-manifest
 spec:
+  chartTimeout: 10m0s # override default Helm install/upgrade timeout for any chart, a go duration: https://golang.org/pkg/time/#ParseDuration
   charts:
   - name: my-chart-1   # the name of the chart
     namespace: default # the namespace where your chart's resources should live
@@ -16,3 +17,4 @@ spec:
   - name: my-chart-2
     namespace: another-namespace # the namespace will be created if it doesn't already exist
     version: 1.7.5
+    timeout: 12m30s # you can also override the Helm install/upgrade timeout on a per-chart basis

--- a/schemas/manifests/v1beta1/schema.go
+++ b/schemas/manifests/v1beta1/schema.go
@@ -26,7 +26,8 @@ type Metadata struct {
 
 // Spec is the v1 schema spec object
 type Spec struct {
-	Charts []*Chart `yaml:"charts,omitempty" json:"charts,omitempty"`
+	ChartTimeout string   `yaml:"chartTimeout,omitempty" json:"chartTimeout,omitempty"`
+	Charts       []*Chart `yaml:"charts,omitempty" json:"charts,omitempty"`
 }
 
 // Chart is a v1 schema Chart object
@@ -35,6 +36,7 @@ type Chart struct {
 	Namespace string      `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 	Version   string      `yaml:"version,omitempty" json:"version,omitempty"`
 	Values    interface{} `yaml:"values,omitempty" json:"-"` // json:"-" here is to ignore generic type validation, otherwise we'd get: json: unsupported type: map[interface {}]interface {}
+	Timeout   string      `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 }
 
 // Replace defines a single item in the list of a chart's "replaces" list

--- a/schemas/manifests/v1beta1/schema.json
+++ b/schemas/manifests/v1beta1/schema.json
@@ -14,7 +14,8 @@
         "name": { "type": "string" },
         "namespace": { "type": "string" },
         "version": { "type": "string" },
-        "values": { "type": [ "object", "null" ] }
+        "values": { "type": [ "object", "null" ] },
+        "timeout": { "type": "string" }
       }
     }
   },
@@ -36,6 +37,7 @@
     "spec": {
       "type": "object",
       "properties": {
+        "chartTimeout": { "type": "string" },
         "charts": {
           "type": "array",
           "items": { "$ref": "#/definitions/chart" }

--- a/schemas/manifests/v1beta1/schema.json.go
+++ b/schemas/manifests/v1beta1/schema.json.go
@@ -20,7 +20,8 @@ const Schema = `
         "name": { "type": "string" },
         "namespace": { "type": "string" },
         "version": { "type": "string" },
-        "values": { "type": [ "object", "null" ] }
+        "values": { "type": [ "object", "null" ] },
+        "timeout": { "type": "string" }
       }
     }
   },
@@ -42,6 +43,7 @@ const Schema = `
     "spec": {
       "type": "object",
       "properties": {
+        "chartTimeout": { "type": "string" },
         "charts": {
           "type": "array",
           "items": { "$ref": "#/definitions/chart" }


### PR DESCRIPTION
…ls/upgrades via manifest

<!--  Thanks for sending a pull request!  Just let us know a bit more below so we can have the info we need to review.

If you're just getting started contributing to Loftsman, make sure you review our contributing guidelines: https://github.com/Cray-HPE/loftsman/blob/main/CONTRIBUTING.md

-->

#### What type of PR is this?

enhancement

#### What this PR does / why we need it:

Allows users to override Helm install/upgrade `--timeout` during a ship

#### Which issue(s) this PR fixes or finishes:

resolves #17 