### PR TITLE
add support for custom release name for a chart in the manifest

### DIFF
--- a/schemas/manifests/v1beta1/examples/comprehensive.yaml
+++ b/schemas/manifests/v1beta1/examples/comprehensive.yaml
@@ -15,6 +15,7 @@ spec:
   # and further charts to be installed or upgraded. Loftsman will go through this charts
   # list and install in order.
   - name: my-chart-2
+    releaseName: my-chart-2-release # by default, the Helm release name will just be the chart name, but you can override it here
     namespace: another-namespace # the namespace will be created if it doesn't already exist
     version: 1.7.5
     timeout: 12m30s # you can also override the Helm install/upgrade timeout on a per-chart basis

--- a/schemas/manifests/v1beta1/manifest.go
+++ b/schemas/manifests/v1beta1/manifest.go
@@ -123,9 +123,13 @@ func (m *Manifest) Release(kubernetes interfaces.Kubernetes, helm interfaces.Hel
 			continue
 		}
 
+		releaseName := chart.Name
+		if chart.ReleaseName != "" {
+			releaseName = chart.ReleaseName
+		}
 		installUpgradeCmd := strings.TrimSpace(fmt.Sprintf(
 			"upgrade --install %s %s --namespace %s --create-namespace --set global.chart.name=%s --set global.chart.version=%s %s",
-			chart.Name,
+			releaseName,
 			chartPath,
 			chart.Namespace,
 			chart.Name,

--- a/schemas/manifests/v1beta1/manifest_test.go
+++ b/schemas/manifests/v1beta1/manifest_test.go
@@ -293,3 +293,29 @@ func TestIndividualChartTimeout(t *testing.T) {
 		t.Errorf("Got unexpected errors from manifest.v1beta1.TestIndividualChartTimeout(): %s", errsToString(errs))
 	}
 }
+
+func TestCustomReleaseName(t *testing.T) {
+	availableChartVersions := []*interfaces.HelmAvailableChartVersion{
+		&interfaces.HelmAvailableChartVersion{
+			Version: "0.0.1",
+			Path:    "/tmp/full-chart-0.0.1.tgz",
+		},
+	}
+	manifest := getTestManifest()
+	manifest.Spec.Charts = []*Chart{
+		&Chart{
+			Name:        "full-chart",
+			ReleaseName: "full-chart-release-1",
+			Namespace:   "default",
+			Version:     "0.0.1",
+			Values: map[string]interface{}{
+				"one": "1",
+				"two": "2",
+			},
+		},
+	}
+	errs := manifest.Release(custommocks.GetKubernetesMock(false), custommocks.GetHelmMock(availableChartVersions))
+	if len(errs) != 0 {
+		t.Errorf("Got unexpected errors from manifest.v1beta1.TestCustomReleaseName(): %s", errsToString(errs))
+	}
+}

--- a/schemas/manifests/v1beta1/schema.go
+++ b/schemas/manifests/v1beta1/schema.go
@@ -32,15 +32,10 @@ type Spec struct {
 
 // Chart is a v1 schema Chart object
 type Chart struct {
-	Name      string      `yaml:"name,omitempty" json:"name,omitempty"`
-	Namespace string      `yaml:"namespace,omitempty" json:"namespace,omitempty"`
-	Version   string      `yaml:"version,omitempty" json:"version,omitempty"`
-	Values    interface{} `yaml:"values,omitempty" json:"-"` // json:"-" here is to ignore generic type validation, otherwise we'd get: json: unsupported type: map[interface {}]interface {}
-	Timeout   string      `yaml:"timeout,omitempty" json:"timeout,omitempty"`
-}
-
-// Replace defines a single item in the list of a chart's "replaces" list
-type Replace struct {
-	Name      string `yaml:"name,omitempty" json:"name,omitempty"`
-	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Name        string      `yaml:"name,omitempty" json:"name,omitempty"`
+	ReleaseName string      `yaml:"releaseName,omitempty" json:"releaseName,omitempty"`
+	Namespace   string      `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Version     string      `yaml:"version,omitempty" json:"version,omitempty"`
+	Values      interface{} `yaml:"values,omitempty" json:"-"` // json:"-" here is to ignore generic type validation, otherwise we'd get: json: unsupported type: map[interface {}]interface {}
+	Timeout     string      `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 }

--- a/schemas/manifests/v1beta1/schema.json
+++ b/schemas/manifests/v1beta1/schema.json
@@ -12,6 +12,7 @@
       ],
       "properties": {
         "name": { "type": "string" },
+        "releaseName": { "type": "string" },
         "namespace": { "type": "string" },
         "version": { "type": "string" },
         "values": { "type": [ "object", "null" ] },

--- a/schemas/manifests/v1beta1/schema.json.go
+++ b/schemas/manifests/v1beta1/schema.json.go
@@ -18,6 +18,7 @@ const Schema = `
       ],
       "properties": {
         "name": { "type": "string" },
+        "releaseName": { "type": "string" },
         "namespace": { "type": "string" },
         "version": { "type": "string" },
         "values": { "type": [ "object", "null" ] },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Just let us know a bit more below so we can have the info we need to review.

If you're just getting started contributing to Loftsman, make sure you review our contributing guidelines: https://github.com/Cray-HPE/loftsman/blob/main/CONTRIBUTING.md

-->

#### What type of PR is this?

enhancement

#### What this PR does / why we need it:

a few different use-cases where we might need to set a custom release name for the chart being installed/upgraded. See #22 for more details

#### Which issue(s) this PR fixes or finishes:

resolves #22 