### PR TITLE
adjust how json logging to output file operates

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -104,9 +104,15 @@ func (log *Logger) GetRecord() string {
 
 // New will return a new instance of a logger
 func New(jsonLogFile *os.File, commandName string) *Logger {
+	var multiWriter io.Writer
 	record = &strings.Builder{}
 	zerologConsoleWriter := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
-	multiWriter := io.MultiWriter(consoleWriter{zerologConsoleWriter: zerologConsoleWriter}, jsonLogFile, record)
+	_, err := jsonLogFile.Stat()
+	if err == nil {
+		multiWriter = io.MultiWriter(consoleWriter{zerologConsoleWriter: zerologConsoleWriter}, jsonLogFile, record)
+	} else {
+		multiWriter = io.MultiWriter(consoleWriter{zerologConsoleWriter: zerologConsoleWriter}, record)
+	}
 	return &Logger{
 		zerolog.New(multiWriter).With().Str("command", commandName).Timestamp().Logger(),
 	}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/Cray-HPE/go-lib/shell"
 	"github.com/Cray-HPE/loftsman/internal/interfaces"
@@ -70,10 +69,9 @@ func (s *Settings) ValidateManifestPath() error {
 
 // New gets a settings object with defaults
 func New() *Settings {
-	cwd, _ := os.Getwd()
 	return &Settings{
 		JSONLog: &JSONLog{
-			Path: filepath.Join(cwd, "loftsman.log"),
+			Path: "",
 		},
 		Namespace:    "loftsman",
 		ChartsSource: &interfaces.HelmChartsSource{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Just let us know a bit more below so we can have the info we need to review.

If you're just getting started contributing to Loftsman, make sure you review our contributing guidelines: https://github.com/Cray-HPE/loftsman/blob/main/CONTRIBUTING.md

-->

#### What type of PR is this?

feature, some might say fix :)

#### What this PR does / why we need it:

always outputting `loftsman.log` JSON log is not appropriate for all. In fact, you probably want to request it explicitly and have the default be just stdout and what gets saved for ship operations in the cluster history, so making that adjustment here.

Some backwards incompatibility in that the default will no longer be to output the json log file by default, but minimal impact and will be released with next minor version accordingly.

#### Which issue(s) this PR fixes or finishes:

resolves #12 
