### PR TITLE
add ability for multiple chart sources in a single ship via new manif…

### DIFF
--- a/CHANGELOG/CHANGELOG-1.1.0-beta1.md
+++ b/CHANGELOG/CHANGELOG-1.1.0-beta1.md
@@ -1,0 +1,8 @@
+### 1.1.0-beta1 Changelog
+
+* Support for pointing at multiple chart sources, both local and remote, added to manifest schema
+* Implement a global and per-chart Helm install/upgrade timeout override in the manifest
+* Ability to set a custom release name for a chart in the manifest, previously would have to be the chart name
+* Improve log file configuration, previously was just `loftsman.log` output always on all commands, we've moved towards a default of not outputting
+* Add pipeline/action to publish an official container image for the Loftman CLI
+* Initial functional testing script added to repo

--- a/CHANGELOG/CHANGELOG-1.1.0-beta2.md
+++ b/CHANGELOG/CHANGELOG-1.1.0-beta2.md
@@ -1,0 +1,4 @@
+### 1.1.0-beta2 Changelog
+
+* Added test for new `Kubernetes.GetSecretKeyValue` for case of data key that doesn't exist
+* Revert staging of generic manifest `spec.all` merging with individual charts. This needs further thought and design

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,15 +128,15 @@ func init() {
 		"A comma-delimited list of charts to initialize in the manifest")
 
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.ChartsSource.Repo, "charts-repo", "", "",
-		"DEPRECATED in favor of manifest chartSources. The root URL for an external helm chart repo to use for\n"+
-			"installing/upgrading charts. (required if not using charts-path)")
+		"DEPRECATED in favor of manifest spec.sources.charts. The root URL for an external helm chart repo to use for\n"+
+			"installing/upgrading charts")
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.ChartsSource.Path, "charts-path", "", "",
-		"DEPRECATED in favor of manifest chartSources. Local path to a directory containing helm-packaged charts,\n"+
-			"e.g. files like my-chart-0.1.0.tgz (required if not using charts-repo)")
+		"DEPRECATED in favor of manifest spec.sources.charts. Local path to a directory containing helm-packaged charts,\n"+
+			"e.g. files like my-chart-0.1.0.tgz")
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.ChartsSource.RepoUsername, "charts-repo-username", "", "",
-		"DEPRECATED in favor of manifest chartSources. The username for charts-repo, if applicable")
+		"DEPRECATED in favor of manifest spec.sources.charts. The username for charts-repo, if applicable")
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.ChartsSource.RepoPassword, "charts-repo-password", "", "",
-		"DEPRECATED in favor of manifest chartSources. The password for charts-repo, if applicable")
+		"DEPRECATED in favor of manifest spec.sources.charts. The password for charts-repo, if applicable")
 
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.Manifest.Path, manifestPathArgName, "", "",
 		"Local path to the Loftsman YAML manifest file, instruction on what charts to install and how to install them.\n"+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,7 +113,8 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVarP(&loftsman.Settings.JSONLog.Path, "json-log-path", "", loftsman.Settings.JSONLog.Path,
-		"Path to the file where JSON/machine-readable logs written, nothing written if empty/absent, note that this is in addition to the stdout logs")
+		"Path to the file where JSON/machine-readable logs written, nothing written if empty/absent, note\n"+
+			"that this is in addition to the stdout logs")
 	rootCmd.PersistentFlags().StringVarP(&loftsman.Settings.Kubernetes.KubeconfigPath, "kubeconfig", "", loftsman.Settings.Kubernetes.KubeconfigPath,
 		"Path to the Kubernetes config file to use (default is the system default)")
 	rootCmd.PersistentFlags().StringVarP(&loftsman.Settings.Kubernetes.KubeContext, "kube-context", "", loftsman.Settings.Kubernetes.KubeContext,
@@ -127,20 +128,23 @@ func init() {
 		"A comma-delimited list of charts to initialize in the manifest")
 
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.ChartsSource.Repo, "charts-repo", "", "",
-		"The root URL for an external helm chart repo to use for installing/upgrading charts. (required if not using charts-path)")
+		"DEPRECATED in favor of manifest chartSources. The root URL for an external helm chart repo to use for\n"+
+			"installing/upgrading charts. (required if not using charts-path)")
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.ChartsSource.Path, "charts-path", "", "",
-		"Local path to a directory containing helm-packaged charts, e.g. files like my-chart-0.1.0.tgz (required if not using charts-repo)")
+		"DEPRECATED in favor of manifest chartSources. Local path to a directory containing helm-packaged charts,\n"+
+			"e.g. files like my-chart-0.1.0.tgz (required if not using charts-repo)")
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.ChartsSource.RepoUsername, "charts-repo-username", "", "",
-		"The username for charts-repo, if applicable")
+		"DEPRECATED in favor of manifest chartSources. The username for charts-repo, if applicable")
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.ChartsSource.RepoPassword, "charts-repo-password", "", "",
-		"The password for charts-repo, if applicable")
+		"DEPRECATED in favor of manifest chartSources. The password for charts-repo, if applicable")
 
 	shipCmd.PersistentFlags().StringVarP(&loftsman.Settings.Manifest.Path, manifestPathArgName, "", "",
-		"Local path to the Loftsman YAML manifest file, instruction on what charts to install and how to install them. See \n"+
-			"loftsman manifest --help for more info (required)")
+		"Local path to the Loftsman YAML manifest file, instruction on what charts to install and how to install them.\n"+
+			"See loftsman manifest --help for more info (required)")
 
 	avastCmd.PersistentFlags().StringVarP(&loftsman.Settings.Manifest.Path, manifestPathArgName, "", "",
-		"Local path to the Loftsman YAML mainfest file, by name it will determine the existing loftsman ship to halt (required if not using manifest-name)")
+		"Local path to the Loftsman YAML mainfest file, by name it will determine the existing loftsman ship to halt\n"+
+			"(required if not using manifest-name)")
 	avastCmd.PersistentFlags().StringVarP(&loftsman.Settings.Manifest.Name, "manifest-name", "", "",
 		fmt.Sprintf("The name of the manifest ship operation you want to halt (required if not using %s)", manifestPathArgName))
 

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -140,3 +140,8 @@ func (h *Helm) GetReleaseStatus(chartName string, chartNamespace string) (*inter
 	}
 	return rs, nil
 }
+
+// GetExecConfig returns the existing ExecConfig
+func (h *Helm) GetExecConfig() *interfaces.HelmExecConfig {
+	return h.ExecConfig
+}

--- a/internal/interfaces/helm.go
+++ b/internal/interfaces/helm.go
@@ -14,6 +14,7 @@ type HelmExecConfig struct {
 
 // HelmChartsSource is an object storing config for where our Helm charts exist
 type HelmChartsSource struct {
+	RepoName     string
 	Repo         string
 	RepoUsername string
 	RepoPassword string
@@ -43,4 +44,5 @@ type Helm interface {
 	Exec(subCommand string) (string, error)
 	GetAvailableChartVersions(chartName string) ([]*HelmAvailableChartVersion, error)
 	GetReleaseStatus(chartName string, chartNamespace string) (*HelmReleaseStatus, error)
+	GetExecConfig() *HelmExecConfig
 }

--- a/internal/interfaces/kubernetes.go
+++ b/internal/interfaces/kubernetes.go
@@ -1,7 +1,7 @@
 package interfaces
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // Kubernetes is the interface for a k8s api object instance
@@ -12,4 +12,5 @@ type Kubernetes interface {
 	FindConfigMap(name string, namespace string, withKey string, withValue string) (*v1.ConfigMap, error)
 	InitializeConfigMap(name string, namespace string, data map[string]string) (*v1.ConfigMap, error)
 	PatchConfigMap(name string, namespace string, data map[string]string) (*v1.ConfigMap, error)
+	GetSecretKeyValue(secretName string, namespace string, dataKey string) (string, error)
 }

--- a/internal/kubernetes/kubernetes_test.go
+++ b/internal/kubernetes/kubernetes_test.go
@@ -150,3 +150,18 @@ func TestPatchConfigMap(t *testing.T) {
 		t.Errorf("Got unexpected error from kubernetes.TestPatchConfigMap(): %s", err)
 	}
 }
+
+func TestGetSecretKeyValue(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET", `=~http://loftsman-tests`, httpmock.NewStringResponder(200, `{"metadata": {"name": "secret-name", "namespace": "default"}, "data": {"test-key": "dGVzdC12YWx1ZQo="}}`))
+	k := &Kubernetes{}
+	_ = k.Initialize("./.test-fixtures/kubeconfig.yaml", "default")
+	value, err := k.GetSecretKeyValue("secret-name", "default", "test-key")
+	if err != nil {
+		t.Errorf("Got unexpected error from kubernetes.TestGetSecretKeyValue(): %s", err)
+	}
+	if value != "test-value" {
+		t.Errorf("Got unexpected value from kubernetes.TestGetSecretKeyValue(): %s", value)
+	}
+}

--- a/internal/kubernetes/kubernetes_test.go
+++ b/internal/kubernetes/kubernetes_test.go
@@ -165,3 +165,18 @@ func TestGetSecretKeyValue(t *testing.T) {
 		t.Errorf("Got unexpected value from kubernetes.TestGetSecretKeyValue(): %s", value)
 	}
 }
+
+func TestGetSecretKeyValueKeyDoesntExist(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET", `=~http://loftsman-tests`, httpmock.NewStringResponder(200, `{"metadata": {"name": "secret-name", "namespace": "default"}, "data": {"test-key": "dGVzdC12YWx1ZQo="}}`))
+	k := &Kubernetes{}
+	_ = k.Initialize("./.test-fixtures/kubeconfig.yaml", "default")
+	value, err := k.GetSecretKeyValue("secret-name", "default", "key-doesnt-exist")
+	if err != nil {
+		t.Errorf("Got unexpected error from kubernetes.TestGetSecretKeyValueKeyDoesntExist(): %s", err)
+	}
+	if value != "" {
+		t.Errorf("Got unexpected value from kubernetes.TestGetSecretKeyValueKeyDoesntExist(): %s", value)
+	}
+}

--- a/internal/manifest/v1beta1_validation_test.go
+++ b/internal/manifest/v1beta1_validation_test.go
@@ -6,20 +6,6 @@ import (
 	"testing"
 )
 
-func TestValidateV1Beta1ValidNoCharts(t *testing.T) {
-	manifest := `---
-apiVersion: manifests/v1beta1
-metadata:
-  name: test-manifest
-spec:
-  charts: []
-`
-	_, err := Validate(manifest)
-	if err != nil {
-		t.Errorf("Got unexpected error from manifest.TestValidateV1Beta1ValidNoCharts(): %s", err)
-	}
-}
-
 func TestValidateV1Beta1ValidWithMinimalChart(t *testing.T) {
 	manifest := `---
 apiVersion: manifests/v1beta1
@@ -84,5 +70,113 @@ metadata:
 	_, err := Validate(manifest)
 	if err == nil || !strings.Contains(err.Error(), "manifest validation errors") {
 		t.Errorf("Didn't get expected error from manifest.TestValidateV1Beta1MissingSpec(), instead got: %s", err)
+	}
+}
+
+func TestValidateV1Beta1MissingCharts(t *testing.T) {
+	manifest := `---
+apiVersion: manifests/v1beta1
+metadata:
+  name: test-manifest
+spec: {}
+`
+	_, err := Validate(manifest)
+	if err == nil || !strings.Contains(err.Error(), "manifest validation errors") {
+		t.Errorf("Didn't get expected error from manifest.TestValidateV1Beta1MissingCharts(), instead got: %s", err)
+	}
+}
+
+func TestValidateV1Beta1MissingSourceOnChartWhileUsingChartsSource(t *testing.T) {
+	manifest := `---
+apiVersion: manifests/v1beta1
+metadata:
+  name: test-manifest
+spec:
+  sources:
+    charts:
+    - type: directory
+      name: local
+      location: ./charts
+  charts:
+  - name: chart1
+    namespace: default
+    version: 1.0.0
+`
+	_, err := Validate(manifest)
+	if err == nil || !strings.Contains(err.Error(), "manifest validation errors") {
+		t.Errorf("Didn't get expected error from manifest.TestValidateV1Beta1MissingSourceOnChartWhileUsingChartsSource(), instead got: %s", err)
+	}
+}
+
+func TestValidateV1Beta1IncompleteChartSource(t *testing.T) {
+	manifest := `---
+apiVersion: manifests/v1beta1
+metadata:
+  name: test-manifest
+spec:
+  sources:
+    charts:
+    - type: directory
+      name: local
+  charts:
+  - name: chart1
+    source: local
+    namespace: default
+    version: 1.0.0
+`
+	_, err := Validate(manifest)
+	if err == nil || !strings.Contains(err.Error(), "manifest validation errors") {
+		t.Errorf("Didn't get expected error from manifest.TestValidateV1Beta1IncompleteChartSource(), instead got: %s", err)
+	}
+}
+
+func TestValidateV1Beta1InvalidChartSourceType(t *testing.T) {
+	manifest := `---
+apiVersion: manifests/v1beta1
+metadata:
+  name: test-manifest
+spec:
+  sources:
+    charts:
+    - type: invalid
+      name: local
+      location: ./charts
+  charts:
+  - name: chart1
+    source: local
+    namespace: default
+    version: 1.0.0
+`
+	_, err := Validate(manifest)
+	if err == nil || !strings.Contains(err.Error(), "manifest validation errors") {
+		t.Errorf("Didn't get expected error from manifest.TestValidateV1Beta1InvalidChartSourceType(), instead got: %s", err)
+	}
+}
+
+func TestValidateV1Beta1ValidRepoChartSource(t *testing.T) {
+	manifest := `---
+apiVersion: manifests/v1beta1
+metadata:
+  name: test-manifest
+spec:
+  sources:
+    charts:
+    - type: repo
+      name: remote
+      location: https://repo
+      credentialsSecret:
+        name: secret
+        namespace: default
+        usernameKey: username
+        passwordKey: password
+  charts:
+  - name: chart1
+    source: remote
+    namespace: default
+    version: 1.0.0
+`
+	_, err := Validate(manifest)
+	if err != nil {
+		t.Errorf("Got unexpected error from manifest.TestValidateV1Beta1ValidRepoChartSource(): %s", err)
 	}
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -47,9 +47,6 @@ func (s *Settings) ValidateChartsSource() error {
 	if s.ChartsSource.Repo != "" && s.ChartsSource.Path != "" {
 		return errors.New("both charts-repo and charts-path are set, you should use one or the other")
 	}
-	if s.ChartsSource.Repo == "" && s.ChartsSource.Path == "" {
-		return errors.New("one of charts-repo or charts-path is required")
-	}
 	if s.ChartsSource.Path != "" {
 		if _, err = os.Stat(s.ChartsSource.Path); os.IsNotExist(err) {
 			return fmt.Errorf("charts-path %s not found", s.ChartsSource.Path)

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -24,16 +24,6 @@ func TestValidateChartsSourceWithChartsPathAndRepo(t *testing.T) {
 	}
 }
 
-func TestValidateChartsSourceWithMissingSettings(t *testing.T) {
-	s := New()
-	s.ChartsSource.Path = ""
-	s.ChartsSource.Repo = ""
-	err := s.ValidateChartsSource()
-	if err == nil || !strings.Contains(err.Error(), "charts-repo or charts-path is required") {
-		t.Errorf("Didn't get expected error when settings.ChartsSource.Path and settings.ChartsSource.Repo are both unset, got: %s", err)
-	}
-}
-
 func TestValidateChartsSourceChartsPathInvalid(t *testing.T) {
 	s := New()
 	s.ChartsSource.Path = "/path/that/does/not/exist/charts.tar.gz"

--- a/mocks/custom-mocks/helm.go
+++ b/mocks/custom-mocks/helm.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/stretchr/testify/mock"
 	helminterface "github.com/Cray-HPE/loftsman/internal/interfaces"
 	helmmocks "github.com/Cray-HPE/loftsman/mocks/interfaces"
+	"github.com/stretchr/testify/mock"
 )
 
 // GetHelmMock will return a common mock for the Helm interface/object
@@ -35,5 +35,6 @@ func GetHelmMock(availableChartVersions []*helminterface.HelmAvailableChartVersi
 		}
 		return rs
 	}, nil)
+	h.On("GetExecConfig").Return(&helminterface.HelmExecConfig{})
 	return h
 }

--- a/mocks/custom-mocks/kubernetes.go
+++ b/mocks/custom-mocks/kubernetes.go
@@ -1,10 +1,15 @@
 package mocks
 
 import (
-	"github.com/stretchr/testify/mock"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubernetesmocks "github.com/Cray-HPE/loftsman/mocks/interfaces"
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// TestSecretKeyValue is just a mock value always returns when using GetSecretKeyValue
+	TestSecretKeyValue = "secret"
 )
 
 // GetKubernetesMock will return a common mock for the Kubernetes interface/object
@@ -28,5 +33,6 @@ func GetKubernetesMock(triggerFoundConfigMap bool) *kubernetesmocks.Kubernetes {
 	}, nil)
 	k.On("InitializeConfigMap", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return(&v1.ConfigMap{}, nil)
 	k.On("PatchConfigMap", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return(&v1.ConfigMap{}, nil)
+	k.On("GetSecretKeyValue", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(TestSecretKeyValue, nil)
 	return k
 }

--- a/mocks/internal/interfaces/Helm.go
+++ b/mocks/internal/interfaces/Helm.go
@@ -56,6 +56,22 @@ func (_m *Helm) GetAvailableChartVersions(chartName string) ([]*interfaces.HelmA
 	return r0, r1
 }
 
+// GetExecConfig provides a mock function with given fields:
+func (_m *Helm) GetExecConfig() *interfaces.HelmExecConfig {
+	ret := _m.Called()
+
+	var r0 *interfaces.HelmExecConfig
+	if rf, ok := ret.Get(0).(func() *interfaces.HelmExecConfig); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*interfaces.HelmExecConfig)
+		}
+	}
+
+	return r0
+}
+
 // GetReleaseStatus provides a mock function with given fields: chartName, chartNamespace
 func (_m *Helm) GetReleaseStatus(chartName string, chartNamespace string) (*interfaces.HelmReleaseStatus, error) {
 	ret := _m.Called(chartName, chartNamespace)

--- a/mocks/internal/interfaces/Kubernetes.go
+++ b/mocks/internal/interfaces/Kubernetes.go
@@ -49,6 +49,27 @@ func (_m *Kubernetes) FindConfigMap(name string, namespace string, withKey strin
 	return r0, r1
 }
 
+// GetSecretKeyValue provides a mock function with given fields: secretName, namespace, dataKey
+func (_m *Kubernetes) GetSecretKeyValue(secretName string, namespace string, dataKey string) (string, error) {
+	ret := _m.Called(secretName, namespace, dataKey)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string, string) string); ok {
+		r0 = rf(secretName, namespace, dataKey)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(secretName, namespace, dataKey)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Initialize provides a mock function with given fields: kubeconfigPath, kubeContext
 func (_m *Kubernetes) Initialize(kubeconfigPath string, kubeContext string) error {
 	ret := _m.Called(kubeconfigPath, kubeContext)

--- a/schemas/manifests/v1beta1/examples/comprehensive.yaml
+++ b/schemas/manifests/v1beta1/examples/comprehensive.yaml
@@ -2,11 +2,40 @@ apiVersion: manifests/v1beta1
 metadata:
   name: simple-manifest
 spec:
-  chartTimeout: 10m0s # override default Helm install/upgrade timeout for any chart, a go duration: https://golang.org/pkg/time/#ParseDuration
+  # sources.charts is our working idea moving forward for pointing Loftsman at different locations
+  # containing Helm charts to pull for install/upgrade during a Loftsman ship. The --charts-* cli args
+  # are deprecated as of Loftsman 1.1.0, and are planned for being phased out by Loftsman v2.x
+  sources:
+    # using spec.sources.charts will take precedence over the --charts-* CLI args
+    charts:
+    - type: directory      # two types currently supported: [directory, repo]
+      name: local          # a source name should be unique in the context of the entire manifest
+      location: ./charts   # can be relative to the path at which you're running `loftsman ship`
+    - type: repo
+      name: myorgrepo
+      location: https://charts.my.org/
+      # If you're dealing with a protected/secured Helm chart repo, you can pre-populate a secret in
+      # Kubernetes with the repo username/password so that Loftsman can authenticate to pull charts
+      # from there.
+      # We're still figuring out where to go with supporting auth mechanisms here around Helm support (SSL auth, OCI support),
+      # but if you have a general helm repo/museum with username/password capbilities, you should be good using these values
+      credentialsSecret:
+        name: myorg-charts-repo-credentials  # the name of the Kubernetes secret
+        namespace: default      # the namespace where the secret lives
+        usernameKey: username   # the secret data key storing the username
+        passwordKey: password   # the secret data key storing the password
+  # 'all' allows a way to set certain properties or default property values automatically on each spec.charts[] without having to
+  # repeat for each one. Everything under this property will be merged with the same properties of each chart as we go through the ship,
+  # the values set in the spec.charts[] entry taking precedence.
+  # Current supported properties to override (the plan is to be able to add support for others like values as well as we move towards 2.x):
+  #   * timeout
+  all:
+    timeout: 10m0s # set default Helm install/upgrade timeout for every chart, a go duration: https://golang.org/pkg/time/#ParseDuration
   charts:
-  - name: my-chart-1   # the name of the chart
-    namespace: default # the namespace where your chart's resources should live
-    version: 1.0.0     # the version of your chart to install
+  - name: my-chart-1     # the name of the chart
+    source: local        # as defined in a sources.charts[].name, this must be set if you're using sources.*
+    namespace: default   # the namespace where your chart's resources should live
+    version: 1.0.0       # the version of your chart to install
     # The values property allows passing in value overrides to your chart install/upgrade
     # e.g. https://helm.sh/docs/chart_template_guide/values_files/
     values:
@@ -15,7 +44,8 @@ spec:
   # and further charts to be installed or upgraded. Loftsman will go through this charts
   # list and install in order.
   - name: my-chart-2
-    releaseName: my-chart-2-release # by default, the Helm release name will just be the chart name, but you can override it here
-    namespace: another-namespace # the namespace will be created if it doesn't already exist
-    version: 1.7.5
-    timeout: 12m30s # you can also override the Helm install/upgrade timeout on a per-chart basis
+    source: myorgrepo                 # as defined in a sources.charts[].name, this must be set if you're using sources.*
+    releaseName: my-chart-2-release   # by default, the Helm release name will just be the chart name, but you can override it here
+    namespace: another-namespace      # the namespace will be created if it doesn't already exist
+    version: 1.7.5                    # the version of the packaged chart to install
+    timeout: 12m30s                   # you can also set the Helm install/upgrade timeout on a per-chart basis, will take precedence over all.timeout

--- a/schemas/manifests/v1beta1/manifest.go
+++ b/schemas/manifests/v1beta1/manifest.go
@@ -40,22 +40,6 @@ func (m *Manifest) Load(manifestContent string) error {
 	if err := yaml.Unmarshal([]byte(manifestContent), &m); err != nil {
 		return err
 	}
-	// We haven't yet validated our resulting, loaded manifest, so we can't assume anything is initialized
-	// TODO: is this going to be a good idea thinking about validating a manifest that's been modified instead
-	//       of always just the original? Not something we have to definitely answer on this round while supporting
-	//       just all.timeout, but when we get to some more generic possibilities (see comment below) we'll
-	//       probably want to settle on some answers
-	if m.Spec != nil && len(m.Spec.Charts) > 0 {
-		for _, chart := range m.Spec.Charts {
-			if m.Spec.All != nil {
-				// TODO: we'll eventually use some generic merge capability here, since we're only supporting all.timeout
-				//       for now, we can simply assume that's the only thing we care about
-				if m.Spec.All.Timeout != "" && chart.Timeout == "" {
-					chart.Timeout = m.Spec.All.Timeout
-				}
-			}
-		}
-	}
 	return nil
 }
 
@@ -134,6 +118,9 @@ CHARTS:
 		// TODO: when we're able to deprecate --charts-* CLI args, we can move to some slightly cleaner patterns here. In order to continue to
 		//       support both manifest-defined chart sources and the CLI ones, and doing as little as possible around it for now, this is deemed the
 		//       best path
+		if m.Spec.All != nil && m.Spec.All.Timeout != "" && chart.Timeout == "" {
+			chart.Timeout = m.Spec.All.Timeout
+		}
 		extraCmdArgs := ""
 		helmChartsSource := &interfaces.HelmChartsSource{}
 		if m.Spec.Sources != nil && len(m.Spec.Sources.Charts) > 0 {

--- a/schemas/manifests/v1beta1/manifest.go
+++ b/schemas/manifests/v1beta1/manifest.go
@@ -93,8 +93,6 @@ func (m *Manifest) Release(kubernetes interfaces.Kubernetes, helm interfaces.Hel
 
 CHARTS:
 	for _, chart := range m.Spec.Charts {
-		data, _ := yaml.Marshal(chart)
-		fmt.Println(string(data))
 		logForChart := func(level zerolog.Level, msg string) {
 			if strings.TrimSpace(msg) == "" {
 				return

--- a/schemas/manifests/v1beta1/manifest_test.go
+++ b/schemas/manifests/v1beta1/manifest_test.go
@@ -52,29 +52,6 @@ spec:
 	}
 }
 
-func TestLoadWithAll(t *testing.T) {
-	manifest := &Manifest{}
-	manifestContent := `---
-apiVersion: manifests/v1beta1
-metadata:
-  name: test-manifest
-spec:
-  all:
-    timeout: 10m0s
-  charts:
-  - name: chart1
-    namespace: default
-    version: 1.0.0
-`
-	err := manifest.Load(manifestContent)
-	if err != nil {
-		t.Errorf("Got unexpected error from manifest.v1beta1.TestLoadWithAll(): %s", err)
-	}
-	if manifest.Spec.Charts[0].Timeout != "10m0s" {
-		t.Errorf("Didn't find expected manifest.Spec.Charts[0].Timeout value of 10m0s from manifest.v1beta.TestLoadWithAll(), instead got: %s", manifest.Spec.Charts[0].Timeout)
-	}
-}
-
 func TestCreateNoCharts(t *testing.T) {
 	manifest := &Manifest{}
 	created, err := manifest.Create([]string{})

--- a/schemas/manifests/v1beta1/schema.json
+++ b/schemas/manifests/v1beta1/schema.json
@@ -5,27 +5,27 @@
   "definitions": {
     "chart": {
       "type": "object",
-      "required": [
-        "name",
-        "namespace",
-        "version"
-      ],
       "properties": {
         "name": { "type": "string" },
+        "source": { "type": "string" },
         "releaseName": { "type": "string" },
         "namespace": { "type": "string" },
         "version": { "type": "string" },
         "values": { "type": [ "object", "null" ] },
         "timeout": { "type": "string" }
-      }
+      },
+      "additionalProperties": false
+    },
+    "all": {
+      "type": "object",
+      "properties": {
+        "timeout": { "type": "string" }
+      },
+      "additionalProperties": false
     }
   },
   "type": "object",
-  "required": [
-    "apiVersion",
-    "metadata",
-    "spec"
-  ],
+  "required": ["apiVersion", "metadata", "spec"],
   "properties": {
     "apiVersion": { "type": "string" },
     "metadata": {
@@ -33,17 +33,83 @@
       "properties": {
         "name": { "type": "string" },
         "labels": { "type": "object" }
-      }
+      },
+      "additionalProperties": false
     },
     "spec": {
       "type": "object",
+      "required": ["charts"],
       "properties": {
-        "chartTimeout": { "type": "string" },
+        "sources": {
+          "type": "object",
+          "properties": {
+            "charts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [ "type", "name", "location" ],
+                "properties": {
+                  "type": { "type": "string", "enum": ["directory", "repo"] },
+                  "name": { "type": "string" },
+                  "location": { "type": "string" },
+                  "credentialsSecret": {
+                    "type": "object",
+                    "required": ["name", "namespace", "usernameKey", "passwordKey"],
+                    "properties": {
+                      "name": { "type": "string" },
+                      "namespace": { "type": "string" },
+                      "usernameKey": { "type": "string" },
+                      "passwordKey": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "repos": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [ "name", "url" ],
+                "properties": {
+                  "name": { "type": "string" },
+                  "url": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "all": { "$ref": "#/definitions/all" },
         "charts": {
           "type": "array",
-          "items": { "$ref": "#/definitions/chart" }
+          "items": {
+            "allOf": [
+              { "$ref": "#/definitions/chart" },
+              { "required": ["name", "namespace", "version"] }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "dependencies": {
+        "sources": {
+          "properties": {
+            "charts": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  { "$ref": "#/definitions/chart" },
+                  { "required": ["name", "source", "namespace", "version"] }
+                ]
+              }
+            }
+          }
         }
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/schemas/manifests/v1beta1/schema.json.go
+++ b/schemas/manifests/v1beta1/schema.json.go
@@ -11,27 +11,27 @@ const Schema = `
   "definitions": {
     "chart": {
       "type": "object",
-      "required": [
-        "name",
-        "namespace",
-        "version"
-      ],
       "properties": {
         "name": { "type": "string" },
+        "source": { "type": "string" },
         "releaseName": { "type": "string" },
         "namespace": { "type": "string" },
         "version": { "type": "string" },
         "values": { "type": [ "object", "null" ] },
         "timeout": { "type": "string" }
-      }
+      },
+      "additionalProperties": false
+    },
+    "all": {
+      "type": "object",
+      "properties": {
+        "timeout": { "type": "string" }
+      },
+      "additionalProperties": false
     }
   },
   "type": "object",
-  "required": [
-    "apiVersion",
-    "metadata",
-    "spec"
-  ],
+  "required": ["apiVersion", "metadata", "spec"],
   "properties": {
     "apiVersion": { "type": "string" },
     "metadata": {
@@ -39,18 +39,84 @@ const Schema = `
       "properties": {
         "name": { "type": "string" },
         "labels": { "type": "object" }
-      }
+      },
+      "additionalProperties": false
     },
     "spec": {
       "type": "object",
+      "required": ["charts"],
       "properties": {
-        "chartTimeout": { "type": "string" },
+        "sources": {
+          "type": "object",
+          "properties": {
+            "charts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [ "type", "name", "location" ],
+                "properties": {
+                  "type": { "type": "string", "enum": ["directory", "repo"] },
+                  "name": { "type": "string" },
+                  "location": { "type": "string" },
+                  "credentialsSecret": {
+                    "type": "object",
+                    "required": ["name", "namespace", "usernameKey", "passwordKey"],
+                    "properties": {
+                      "name": { "type": "string" },
+                      "namespace": { "type": "string" },
+                      "usernameKey": { "type": "string" },
+                      "passwordKey": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "repos": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [ "name", "url" ],
+                "properties": {
+                  "name": { "type": "string" },
+                  "url": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "all": { "$ref": "#/definitions/all" },
         "charts": {
           "type": "array",
-          "items": { "$ref": "#/definitions/chart" }
+          "items": {
+            "allOf": [
+              { "$ref": "#/definitions/chart" },
+              { "required": ["name", "namespace", "version"] }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "dependencies": {
+        "sources": {
+          "properties": {
+            "charts": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  { "$ref": "#/definitions/chart" },
+                  { "required": ["name", "source", "namespace", "version"] }
+                ]
+              }
+            }
+          }
         }
       }
     }
-  }
+  },
+  "additionalProperties": false
 }
 `

--- a/scripts/tests-functional/.gitignore
+++ b/scripts/tests-functional/.gitignore
@@ -1,0 +1,1 @@
+/loftsman

--- a/scripts/tests-functional/charts/.gitignore
+++ b/scripts/tests-functional/charts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/tests-functional/run.sh
+++ b/scripts/tests-functional/run.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -e
+
+divider="------------------------------------------------------------------------------------------"
+kind_cluster_name="loftsman-functional-tests"
+consul_chart_version="0.31.1"
+chartmuseum_container_name="${kind_cluster_name}-chartmuseum"
+
+this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $this_dir/../../
+
+if ! command -v helm &>/dev/null; then
+  echo "The helm binary needs to be installed to run functional tests"
+  exit 1
+fi
+if ! command -v kind &>/dev/null; then
+  echo "Kubernetes in Docker (KIND) is required to run functional tests (https://kind.sigs.k8s.io/)"
+  exit 1
+fi
+
+if kind get clusters | grep "^$kind_cluster_name$" &>/dev/null; then
+  kind delete cluster --name $kind_cluster_name
+fi
+rm $this_dir/charts/*.tgz &>/dev/null || true
+rm $this_dir/charts/*.yaml &>/dev/null || true
+docker rm -f $chartmuseum_container_name &>/dev/null || true
+
+revert_context=""
+if kubectl config current-context &>/dev/null; then
+  revert_context=$(kubectl config current-context)
+fi
+
+################################# Manifest chart sources ######################################
+echo $divider
+echo "Manifest chart sources"
+kind create cluster --name $kind_cluster_name
+kubectl config use-context kind-${kind_cluster_name}
+
+# pull some test charts to include the local directory chart source in tests
+helm fetch https://helm.releases.hashicorp.com/consul-${consul_chart_version}.tgz -d $this_dir/charts/
+
+go run . ship --manifest-path $this_dir/test-manifests/chart-sources.yaml
+
+kind delete cluster --name $kind_cluster_name
+rm $this_dir/charts/*.tgz
+
+################################# Pre 1.1.0, CLI args ######################################
+echo $divider
+echo "Pre 1.1.0, CLI args"
+kind create cluster --name $kind_cluster_name
+kubectl config use-context kind-${kind_cluster_name}
+
+helm fetch https://helm.releases.hashicorp.com/consul-${consul_chart_version}.tgz -d $this_dir/charts/
+helm fetch https://victoriametrics.github.io/helm-charts/packages/victoria-metrics-cluster-0.8.24.tgz -d $this_dir/charts/
+
+go run . ship --charts-path $this_dir/charts --manifest-path $this_dir/test-manifests/pre-1.1.0.yaml
+
+kind delete cluster --name $kind_cluster_name
+
+################################# Chart source repo with creds ######################################
+echo $divider
+echo "Manifest chart source repo with creds"
+kind create cluster --name $kind_cluster_name
+kubectl config use-context kind-${kind_cluster_name}
+
+# run a chart museum container with auth set up
+docker run --rm -d --name $chartmuseum_container_name \
+  -p 8080:8080 \
+  -e STORAGE=local \
+  -e STORAGE_LOCAL_ROOTDIR=/charts \
+  -v $this_dir/charts:/charts \
+  chartmuseum/chartmuseum:latest \
+  --basic-auth-user=user \
+  --basic-auth-pass=pass
+
+kubectl create secret generic repo-creds --from-literal=username=user --from-literal=password=pass
+
+go run . ship --manifest-path $this_dir/test-manifests/chart-source-repo-creds.yaml
+
+docker rm -f $chartmuseum_container_name &>/dev/null || true
+kind delete cluster --name $kind_cluster_name
+rm $this_dir/charts/*.tgz
+
+if [ ! -z "$revert_context" ]; then
+  kubectl config use-context $revert_context
+fi

--- a/scripts/tests-functional/test-manifests/chart-source-repo-creds.yaml
+++ b/scripts/tests-functional/test-manifests/chart-source-repo-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: manifests/v1beta1
+metadata:
+  name: functional-tests-full
+spec:
+  sources:
+    charts:
+    - type: repo
+      name: chartmuseum
+      location: http://localhost:8080
+      credentialsSecret:
+        name: repo-creds
+        namespace: default
+        usernameKey: username
+        passwordKey: password
+  charts:
+  - name: consul
+    source: chartmuseum
+    namespace: default
+    version: 0.31.1
+    values:
+      metrics:
+        enabled: true
+  - name: victoria-metrics-cluster
+    source: chartmuseum
+    namespace: default
+    version: 0.8.24

--- a/scripts/tests-functional/test-manifests/chart-sources.yaml
+++ b/scripts/tests-functional/test-manifests/chart-sources.yaml
@@ -1,0 +1,28 @@
+apiVersion: manifests/v1beta1
+metadata:
+  name: functional-tests-full
+spec:
+  sources:
+    charts:
+    - type: directory
+      name: local
+      location: ./scripts/tests-functional/charts
+    - type: repo
+      name: victoria-metrics
+      location: https://victoriametrics.github.io/helm-charts/
+  all:
+    timeout: 2m0s
+  charts:
+  - name: consul
+    source: local
+    namespace: default
+    version: 0.31.1
+    timeout: 8m0s
+    values:
+      metrics:
+        enabled: true
+  - name: victoria-metrics-cluster
+    source: victoria-metrics
+    namespace: default
+    releaseName: vmetrics
+    version: 0.8.24

--- a/scripts/tests-functional/test-manifests/pre-1.1.0.yaml
+++ b/scripts/tests-functional/test-manifests/pre-1.1.0.yaml
@@ -1,0 +1,14 @@
+apiVersion: manifests/v1beta1
+metadata:
+  name: functional-tests-pre-1-1-0
+spec:
+  charts:
+  - name: consul
+    namespace: default
+    version: 0.31.1
+    values:
+      metrics:
+        enabled: true
+  - name: victoria-metrics-cluster
+    namespace: default
+    version: 0.8.24


### PR DESCRIPTION
…est spec.sources.charts section

<!--  Thanks for sending a pull request!  Just let us know a bit more below so we can have the info we need to review.

If you're just getting started contributing to Loftsman, make sure you review our contributing guidelines: https://github.com/Cray-HPE/loftsman/blob/main/CONTRIBUTING.md

-->

#### What type of PR is this?

enhancement

#### What this PR does / why we need it:

We're continuing to build out our initial `manifests/v1beta1` schema. This change officially deprecates the `--charts-*` CLI args in favor manifest-defined chart sources/configuration. We can point to multiple places where charts exist in a single ship with this change which provides much more flexibility around use-cases like those of mixed manifests containing both third-party and internally developed charts.

I've taken this chance to add some initial functional testing capabilities as well under `scripts/tests-functional`. I'm not yet wiring this up to run in automated ways yet, but at least we have it to run locally as we're working on any future efforts.

#### Which issue(s) this PR fixes or finishes:

#24 